### PR TITLE
Enable per-project history with env var

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,9 @@ you have to do is:
 
   $ flask shell
 
+You may set ``FLASK_PTHISTORY`` environment variable to a path of a file to
+enable persistent history.
+
 
 Alternatives
 ============

--- a/flask_shell_ptpython.py
+++ b/flask_shell_ptpython.py
@@ -34,4 +34,6 @@ def shell_command():
 
     ctx.update(app.make_shell_context())
 
-    embed(globals=ctx)
+    # Enable history with FLASK_PTHISTORY pointing to a file.
+    history = os.environ.get('FLASK_PTHISTORY')
+    embed(globals=ctx, history_filename=history)


### PR DESCRIPTION
Hi @jacquerie ,

Here is a non-intrusive implementation of #13 . The idea is that flask-shell-ptpython should not have global history, but a per-project history. For now, i suggest to let user enable history persistence by telling flask-shell-ptpython where to save entries. This may vary whether you're in development or other installation. One can easily add `FLASK_PTHISTORY` in `.envrc` and forget.

What do you think of this ?

Thanks for Flask-Shell-ptpython !