### PR TITLE
fixed pytest-flake8 version number

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ docs_require = []
 
 tests_require = [
     'flake8-future-import>=0.4.3',
-    'pytest-flake8>=.0.9.1',
+    'pytest-flake8>=0.9.1',
 ]
 
 extras_require = {


### PR DESCRIPTION
Without this patch, installation fails with this error:

```
Processing /home/azmeuk/dev/flask-shell-ptpython
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [3 lines of output]
      /home/azmeuk/.local/share/virtualenvs/flask-shell-ptpython-yirf/lib/python3.10/site-packages/setuptools/installer.py:27: SetuptoolsDeprecationWarning: setuptools.installer is deprecated. Requirements should be satisfied by a PEP 517 installer.
        warnings.warn(
      error in flask-shell-ptpython setup command: 'extras_require' must be a dictionary whose values are strings or lists of strings containing valid project/version requirement specifiers.
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```